### PR TITLE
Add default value for postingValidator.

### DIFF
--- a/frontend/src/entries.ts
+++ b/frontend/src/entries.ts
@@ -12,18 +12,10 @@ import {
   union,
 } from "./lib/validation";
 
-export class Posting {
+export interface Posting {
   account: string;
-
   amount: string;
-
   meta: EntryMetadata;
-
-  constructor(account: string, amount: string, meta: EntryMetadata | null) {
-    this.account = account;
-    this.amount = amount;
-    this.meta = meta ?? {};
-  }
 }
 
 const entry_meta_validator = record(

--- a/frontend/src/entries.ts
+++ b/frontend/src/entries.ts
@@ -33,7 +33,7 @@ const entry_meta_validator = record(
 const postingValidator = object({
   account: string,
   amount: string,
-  meta: entry_meta_validator,
+  meta: defaultValue(entry_meta_validator, {}),
 });
 
 interface Amount {

--- a/frontend/src/entries.ts
+++ b/frontend/src/entries.ts
@@ -25,7 +25,7 @@ const entry_meta_validator = record(
 const postingValidator = object({
   account: string,
   amount: string,
-  meta: defaultValue(entry_meta_validator, {}),
+  meta: defaultValue(entry_meta_validator, { test: "value" } as EntryMetadata),
 });
 
 interface Amount {

--- a/frontend/src/entries.ts
+++ b/frontend/src/entries.ts
@@ -25,7 +25,7 @@ const entry_meta_validator = record(
 const postingValidator = object({
   account: string,
   amount: string,
-  meta: defaultValue(entry_meta_validator, { test: "value" } as EntryMetadata),
+  meta: defaultValue(entry_meta_validator, {}),
 });
 
 interface Amount {

--- a/frontend/src/entries.ts
+++ b/frontend/src/entries.ts
@@ -12,10 +12,18 @@ import {
   union,
 } from "./lib/validation";
 
-export interface Posting {
+export class Posting {
   account: string;
+
   amount: string;
+
   meta: EntryMetadata;
+
+  constructor(account: string, amount: string, meta: EntryMetadata | null) {
+    this.account = account;
+    this.amount = amount;
+    this.meta = meta ?? {};
+  }
 }
 
 const entry_meta_validator = record(


### PR DESCRIPTION
<!--
Hi, thank you for opening a PR!

Please ensure that your change passes tests and the various linters by running
`make test` and `make lint`. If testable, your changes should be covered by
unit tests.

Explain your changes below and link to related issues.
-->

In https://github.com/beancount/fava/pull/1722 we assumed that the backend can handle (and return!) `None` values for posting metadata, but that the frontend will always have them defined. 

If we do not handle this, every posting without metadata will result in a validation error in the frontend.

Instead, we need the frontend validator to silently create an empty `EntryMetadata`  when we get `None` (the `meta` field doesn't exist in the JSON). This way the backend accepts `None` while the frontend can process the empty JSON, and we still reuse the `EntryMetadata` components.